### PR TITLE
Refactor CMake build and improve Boost integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,13 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get update 
+        sudo apt-get update
         sudo apt-get install -y \
           build-essential \
           cmake \
           ninja-build \
           libboost-system-dev \
+          libboost-dev \
           libssl-dev \
           pkg-config
 
@@ -51,15 +52,17 @@ jobs:
 
     - name: Setup MSVC
       uses: microsoft/setup-msbuild@v2
-
-    - name: Install vcpkg dependencies
+    # ensure we use the runner’s vcpkg and triplet
+    - name: Install vcpkg dependencies (x64)
+      shell: pwsh
       run: |
-        vcpkg install boost-system:x64-windows
-        vcpkg install openssl:x64-windows
+          vcpkg install boost-headers:x64-windows boost-asio:x64-windows boost-system:x64-windows openssl:x64-windows
 
-    - name: Configure CMake
+    - name: Configure CMake (vcpkg toolchain)
+      shell: pwsh
       run: |
-        cmake --preset windows-default -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+        cmake --preset windows-default
+         -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake"
 
     - name: Build
       run: cmake --build --preset windows-default --config Release
@@ -67,7 +70,7 @@ jobs:
     - name: Test run
       run: |
         cd build/windows-default/Release
-        ./agent.exe --help
+        .\agent.exe --help
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,52 +1,31 @@
 cmake_minimum_required(VERSION 3.20)
 project(blood-profiler VERSION 1.0.0 LANGUAGES CXX)
 
-# Set C++17 standard
+# Language/compile settings
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-
-# Enable position independent code
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# Find required packages
-find_package(Boost REQUIRED COMPONENTS system)
-find_package(OpenSSL REQUIRED)
-
-# Add third-party libraries directory
-add_subdirectory(third_party)
-
-# Add source directory
-add_subdirectory(src)
-
-# Create the agent executable
-add_executable(agent
-    src/main.cpp
-    src/agent.cpp
-    src/probes/tcp_probe.cpp
-    src/probes/https_probe.cpp
-    src/probes/udp_probe.cpp
-    src/utils/json_reporter.cpp
-)
-
-target_include_directories(agent PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/src
-    ${CMAKE_CURRENT_SOURCE_DIR}/third_party/CLI11/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/third_party/nlohmann_json/include
-)
-
-target_link_libraries(agent PRIVATE
-    Boost::system
-    OpenSSL::SSL
-    OpenSSL::Crypto
-)
-
-# Compiler specific settings
-if(MSVC)
-    target_compile_options(agent PRIVATE /W4)
-else()
-    target_compile_options(agent PRIVATE -Wall -Wextra -Wpedantic)
+# Prefer Boost CONFIG packages (vcpkg). Fall back to legacy FindBoost on platforms without them.
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+endif()
+find_package(Boost 1.71 QUIET CONFIG COMPONENTS asio system)
+if(NOT Boost_FOUND)
+  message(STATUS "Boost CONFIG not found; falling back to legacy FindBoost (module).")
+  cmake_policy(PUSH)
+  if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 OLD) # allow module lookup
+  endif()
+  find_package(Boost REQUIRED COMPONENTS system) # headers will be in Boost_INCLUDE_DIRS
+  cmake_policy(POP)
 endif()
 
-# Install targets
-install(TARGETS agent DESTINATION bin)
+find_package(OpenSSL REQUIRED)
+find_package(Threads REQUIRED)
+
+# Hand control to subdirs; they will declare targets and link to these deps.
+add_subdirectory(third_party)
+add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,1 +1,50 @@
-# Source files for blood-profiler agent
+# Define the agent executable owned by src/
+
+add_executable(agent
+		main.cpp
+		agent.cpp
+		probes/tcp_probe.cpp
+		probes/udp_probe.cpp
+		probes/https_probe.cpp
+		utils/json_reporter.cpp
+)
+
+# Local includes
+target_include_directories(agent PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+# Link third-party interface libs
+target_link_libraries(agent PRIVATE
+		CLI11
+		nlohmann_json
+		OpenSSL::SSL
+	OpenSSL::Crypto
+	Threads::Threads
+)
+
+# Link Boost (both CONFIG and legacy module cases)
+if(TARGET Boost::asio)
+	target_link_libraries(agent PRIVATE Boost::asio)
+endif()
+if(TARGET Boost::system)
+	target_link_libraries(agent PRIVATE Boost::system)
+endif()
+
+# Ensure headers are visible in legacy FindBoost case
+if(DEFINED Boost_INCLUDE_DIRS)
+	target_include_directories(agent PRIVATE ${Boost_INCLUDE_DIRS})
+endif()
+
+# Windows socket libs
+if(WIN32)
+	target_link_libraries(agent PRIVATE ws2_32)
+endif()
+
+# Warnings
+if(MSVC)
+	target_compile_options(agent PRIVATE /W4)
+else()
+	target_compile_options(agent PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+# Install
+install(TARGETS agent DESTINATION bin)

--- a/src/probes/https_probe.hpp
+++ b/src/probes/https_probe.hpp
@@ -9,17 +9,18 @@ namespace BloodProfiler {
 
 class HttpsProbe : public ProbeBase {
 public:
-    HttpsProbe(const std::string& host, int port, int timeout_ms, const std::string& sni_override = "");
-    ~HttpsProbe() override = default;
+  HttpsProbe(const std::string &host, int port, int timeout_ms,
+             const std::string &sni_override = "");
+  ~HttpsProbe() override = default;
 
-    ProbeResult execute() override;
-    std::string getType() const override { return "HTTPS"; }
+  ProbeResult execute() override;
+  std::string getType() const override { return "HTTPS"; }
 
 private:
-    std::string host_;
-    int port_;
-    int timeout_ms_;
-    std::string sni_override_;
+  std::string host_;
+  int port_;
+  int timeout_ms_;
+  std::string sni_override_;
 };
 
 } // namespace BloodProfiler

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,2 +1,8 @@
 # Third-party libraries are header-only and vendored
-# CLI11 and nlohmann/json are included via include directories in main CMakeLists.txt
+# Expose them as INTERFACE targets used by the main target(s).
+
+add_library(CLI11 INTERFACE)
+target_include_directories(CLI11 INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/CLI11/include)
+
+add_library(nlohmann_json INTERFACE)
+target_include_directories(nlohmann_json INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/nlohmann_json/include)


### PR DESCRIPTION
Reorganized CMake configuration to delegate target creation to src/CMakeLists.txt, added INTERFACE targets for third-party headers, and improved Boost detection to prefer CONFIG packages with fallback to legacy FindBoost. Updated GitHub Actions workflow for more robust dependency installation and Windows build steps. Minor code style improvements in https_probe.hpp.