### PR TITLE
Improve CMake presets and Windows build configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,10 +92,3 @@ jobs:
         with:
           name: agent-windows
           path: build/windows-default/src/Release/agent.exe
-
-      - name: Configure CMake (vcpkg toolchain)
-        shell: pwsh
-        run: >
-          cmake --preset windows-default
-          -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake"
-          -DVCPKG_TARGET_TRIPLET=x64-windows

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,24 +8,30 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# Prefer Boost CONFIG packages (vcpkg). Fall back to legacy FindBoost on platforms without them.
+# Prefer Boost CONFIG packages (vcpkg). Fall back to legacy FindBoost.
 if(POLICY CMP0167)
   cmake_policy(SET CMP0167 NEW)
 endif()
-find_package(Boost 1.71 QUIET CONFIG COMPONENTS asio system)
+find_package(Boost 1.71 QUIET CONFIG COMPONENTS system)
 if(NOT Boost_FOUND)
   message(STATUS "Boost CONFIG not found; falling back to legacy FindBoost (module).")
   cmake_policy(PUSH)
   if(POLICY CMP0167)
     cmake_policy(SET CMP0167 OLD) # allow module lookup
   endif()
-  find_package(Boost REQUIRED COMPONENTS system) # headers will be in Boost_INCLUDE_DIRS
+  find_package(Boost REQUIRED COMPONENTS system) # headers in Boost_INCLUDE_DIRS
   cmake_policy(POP)
 endif()
 
 find_package(OpenSSL REQUIRED)
 find_package(Threads REQUIRED)
 
-# Hand control to subdirs; they will declare targets and link to these deps.
+# Install: default to a writable location inside the build dir to avoid Program Files
+include(GNUInstallDirs)
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Install prefix" FORCE)
+endif()
+
+# Delegate to subdirs
 add_subdirectory(third_party)
 add_subdirectory(src)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -43,6 +43,16 @@
             }
         },
         {
+            "name": "windows-vcpkg",
+            "displayName": "Windows x64 with vcpkg toolchain",
+            "description": "Uses local wrapper toolchain that requires VCPKG_INSTALLATION_ROOT",
+            "inherits": ["windows-default"],
+            "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/cmake/toolchains/vcpkg-toolchain.cmake",
+                "VCPKG_TARGET_TRIPLET": "x64-windows"
+            }
+        },
+        {
             "name": "linux-default",
             "displayName": "Linux Default",
             "description": "Default Linux build",
@@ -70,6 +80,10 @@
         {
             "name": "windows-default",
             "configurePreset": "windows-default"
+        },
+        {
+            "name": "windows-vcpkg",
+            "configurePreset": "windows-vcpkg"
         },
         {
             "name": "linux-default",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,19 +14,19 @@ target_include_directories(agent PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Link third-party interface libs
 target_link_libraries(agent PRIVATE
-		CLI11
-		nlohmann_json
-		OpenSSL::SSL
-	OpenSSL::Crypto
-	Threads::Threads
+  CLI11
+  nlohmann_json
+  OpenSSL::SSL
+  OpenSSL::Crypto
+  Threads::Threads
 )
 
 # Link Boost (both CONFIG and legacy module cases)
 if(TARGET Boost::asio)
-	target_link_libraries(agent PRIVATE Boost::asio)
+  target_link_libraries(agent PRIVATE Boost::asio)
 endif()
 if(TARGET Boost::system)
-	target_link_libraries(agent PRIVATE Boost::system)
+  target_link_libraries(agent PRIVATE Boost::system)
 endif()
 
 # Ensure headers are visible in legacy FindBoost case
@@ -36,14 +36,16 @@ endif()
 
 # Windows socket libs
 if(WIN32)
-	target_link_libraries(agent PRIVATE ws2_32)
+  # Silence Boost.Asio _WIN32_WINNT notice and target Win10 APIs
+  target_compile_definitions(agent PRIVATE _WIN32_WINNT=0x0A00 WINVER=0x0A00)
+  target_link_libraries(agent PRIVATE ws2_32 crypt32)
 endif()
 
 # Warnings
 if(MSVC)
-	target_compile_options(agent PRIVATE /W4)
+  target_compile_options(agent PRIVATE /W4)
 else()
-	target_compile_options(agent PRIVATE -Wall -Wextra -Wpedantic)
+  target_compile_options(agent PRIVATE -Wall -Wextra -Wpedantic)
 endif()
 
 # Install


### PR DESCRIPTION
Added a 'windows-vcpkg' CMake preset for easier vcpkg toolchain usage and removed redundant vcpkg configuration from the GitHub Actions workflow. Updated CMakeLists to set a default install prefix inside the build directory and clarified Boost package handling. Enhanced Windows build by defining _WIN32_WINNT and WINVER for Boost.Asio and linking crypt32.